### PR TITLE
🐛💄 Force placeholder opacity

### DIFF
--- a/addon/styles/ember-amount-input.css
+++ b/addon/styles/ember-amount-input.css
@@ -34,6 +34,7 @@
 
 .amount-input__value::placeholder {
   color: #b8bccc; /* TODO: import as variable? */
+  opacity: 1; /* Needs to be forced as firefox and ember-cli-addon-docs reduce it */
 }
 
 .amount-input__value.disabled {


### PR DESCRIPTION
# Description
[//]: # "Please include a summary of the change and which issue is fixed. Imagine you're trying to explain the changes to a reviewer."
Firefox applies an opacity on input placeholder, which creates a difference between the currency and placeholder.
Also, `ember-cli-addon-docs` adds opacity too.
See:
<img width="127" alt="capture d ecran 2019-02-20 17 36 50" src="https://user-images.githubusercontent.com/16031781/53107811-26fafd80-3536-11e9-9a2a-1231b9f383d2.png">

[//]: # "Add if relevant, remove if not"
**Changes**
* Force opacity on placeholder

# Type of change
[//]: # "Please delete options that are not relevant, or add what is."
* Bug fix

# Screenshots
[//]: # "Please add screenshots if you made any UI changes."
<img width="932" alt="capture d ecran 2019-02-20 17 43 46" src="https://user-images.githubusercontent.com/16031781/53108299-15febc00-3537-11e9-992d-12941903441b.png">


# Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
Check the input in the demo: https://qonto.github.io/ember-amount-input/versions/master/docs/components/amount-input

# Review requests
[//]: # "Please delete options that are not relevant, or add what is."

* Style
