### PR TITLE
💥 Drop node 8 support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "qunit-dom": "^0.9.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
#### Description
This PR aims to drop `node 8` support as it has reaches is end of life
see https://nodejs.org/en/about/releases/

#### Changes
[//]: # "Add if relevant, remove if not"
* Update `package.json` to udpdate engines
* Update `.travis-ci.yml`

