### PR TITLE
🔧 add Dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"
+    default_labels:
+      - "dependencies"
+    automerged_updates:
+      - match:
+          update_type: "in_range"
+    version_requirement_updates: "increase_versions"


### PR DESCRIPTION
## Description
This aims to add the .depandabot/config.yml file in the repo to in order to have a local configuratoin instead of inheriting from the organization settings.

## Changes
Add .dependabot/config.yml