### PR TITLE
:wheelchair: add id attribute to input

### DIFF
--- a/addon/components/amount-input/template.hbs
+++ b/addon/components/amount-input/template.hbs
@@ -2,6 +2,7 @@
 
 <input
   class="amount-input__value {{ inputClass }} {{ if disabled "disabled" }}"
+  id="amount-input"
   type="number"
   value={{value}}
   step={{step}}


### PR DESCRIPTION
#### Description
[//]: # Adds an `id` attribute to the `<input>` in the template. This will allow users to include an associated `<label for="">` to improve accessibility.

#### Changes
* Adds an `id` of `amount-input` to the `<input>` in the template. 

#### Reproduction instructions
[//]: # This is a very simple change that does not alter the behavior of the addon.
