### PR TITLE
inputmask . when numberOfDecimals=0 and always mask e key

### DIFF
--- a/addon/components/amount-input/component.js
+++ b/addon/components/amount-input/component.js
@@ -3,6 +3,7 @@ import layout from './template'
 
 const KEY_CODE_E = 69
 const KEY_CODE_FULLSTOP = 190
+const KEY_CODE_COMMA = 188
 
 /**
   A amount/money input component. Usage:
@@ -80,7 +81,7 @@ export default Component.extend({
       return false
     } else if (
       this.numberOfDecimal === 0 &&
-      event.keyCode === KEY_CODE_FULLSTOP
+      [KEY_CODE_FULLSTOP, KEY_CODE_COMMA].includes(event.keyCode)
     ) {
       return false
     }

--- a/addon/components/amount-input/component.js
+++ b/addon/components/amount-input/component.js
@@ -1,6 +1,9 @@
 import Component from '@ember/component'
 import layout from './template'
 
+const KEY_CODE_E = 69
+const KEY_CODE_FULLSTOP = 190
+
 /**
   A amount/money input component. Usage:
 
@@ -71,6 +74,17 @@ export default Component.extend({
     @required
   */
   update() {},
+
+  keyDown(event) {
+    if (event.keyCode === KEY_CODE_E) {
+      return false
+    } else if (
+      this.numberOfDecimal === 0 &&
+      event.keyCode === KEY_CODE_FULLSTOP
+    ) {
+      return false
+    }
+  },
 
   input(e) {
     var { value } = e.target

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit'
 import { setupRenderingTest } from 'ember-qunit'
-import { blur, fillIn, render } from '@ember/test-helpers'
+import { blur, fillIn, render, typeIn } from '@ember/test-helpers'
 import hbs from 'htmlbars-inline-precompile'
 
 module('Integration | Component | amount-input', function(hooks) {
@@ -33,8 +33,57 @@ module('Integration | Component | amount-input', function(hooks) {
 
     await fillIn('input', '10.726')
     await blur('input')
+
     assert.dom('input').hasValue('11')
 
     assert.dom('input').hasAttribute('placeholder', '1.000.000')
+  })
+
+  test('e and . key should be masked when numberOfDecimal={{0}}', async function(assert) {
+    this.set('value', 1)
+
+    await render(hbs`
+      {{amount-input
+        numberOfDecimal=0
+        value=value
+        update=(action (mut value)) }}
+    `)
+
+    assert.dom('input').hasValue('1')
+
+    await typeIn('input', 'e')
+    await blur('input')
+
+    assert.dom('input').hasValue('')
+
+    await typeIn('input', 'e231')
+    await blur('input')
+
+    assert.dom('input').hasValue('231')
+
+    await typeIn('input', '.')
+    await blur('input')
+
+    assert.dom('input').hasValue('')
+
+    await typeIn('input', '.455')
+    await blur('input')
+
+    assert.dom('input').hasValue('455')
+
+    await fillIn('input', '12.455')
+    await blur('input')
+
+    assert.dom('input').hasValue('12')
+
+    await fillIn('input', '12.6')
+    await blur('input')
+
+    assert.dom('input').hasValue('13')
+
+    await fillIn('input', 'e13.6')
+    await blur('input')
+
+    assert.dom('input').hasValue('')
   })
 })

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | amount-input', function(hooks) {
     assert.dom('input').hasAttribute('placeholder', '1.000.000')
   })
 
-  test('e and . key should be masked when numberOfDecimal={{0}}', async function(assert) {
+  test('e, . and , key should be masked when numberOfDecimal={{0}}', async function(assert) {
     this.set('value', 1)
 
     await render(hbs`
@@ -85,5 +85,15 @@ module('Integration | Component | amount-input', function(hooks) {
     await blur('input')
 
     assert.dom('input').hasValue('')
+
+    await typeIn('input', ',61')
+    await blur('input')
+
+    assert.dom('input').hasValue('61')
+
+    await typeIn('input', '0,61')
+    await blur('input')
+
+    assert.dom('input').hasValue('61')
   })
 })


### PR DESCRIPTION
#### Description
- Disallows 'e' key on input
- Disallows '.' keypress when numberOfDecimals is 0
- Disallows ',' keypress for french keyboard when numberOfDecimals is 0 

Also fixes https://github.com/qonto/ember-amount-input/issues/149