### PR TITLE
Drop NodeJs 10 and 13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "10"
+  - "12"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "12.* || >= 14.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR drops support for NodeJs 10 and 13. These versions are eol ([NodeJs versions schedule](https://nodejs.org/en/about/releases/)).

It should be released in major version.