### PR TITLE
Increase browser timeout in testem config

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,8 +1,11 @@
+'use strict'
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
It takes the latest config from [ember-cli blueprints](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/testem.js).