### PR TITLE
Add readonly attribute as prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /testem.log
 /yarn-error.log
 /.DS_Store
+/.eslintcache
 
 # ember-try
 /.node_modules.ember-try/

--- a/addon/components/amount-input/template.hbs
+++ b/addon/components/amount-input/template.hbs
@@ -7,4 +7,6 @@
   value={{this.value}}
   step={{this.step}}
   placeholder={{this.placeholder}}
-  disabled={{this.disabled}} >
+  disabled={{this.disabled}}
+  readonly={{this.readonly}}
+>

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>Ember AmountInput</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/pods/docs/components/amount-input/template.hbs
+++ b/tests/dummy/app/pods/docs/components/amount-input/template.hbs
@@ -22,6 +22,17 @@
   {{demo.snippet "amount-input-disabled"}}
 {{/docs-demo}}
 
+<h2>Readonly</h2>
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="amount-input-readonly"}}
+    {{amount-input
+      value=924.67
+      readonly=true }}
+  {{/demo.example}}
+  {{demo.snippet "amount-input-readonly"}}
+{{/docs-demo}}
+
 <h2>Advanced</h2>
 
 {{#docs-demo as |demo|}}


### PR DESCRIPTION
#### Description

Added the readonly attribute as prop. Closes #307

#### Changes

* Added the readonly attribute as prop
* Fix docs title from **Dummy** to **Ember AmountInput**

### Checklist 
- [ ] Obvisously, add your option

- [ ] Do not forget to write inline documentation for your code in addon/components/amount-input

- [ ] Add a test, probably in tests/integration/components/amount-input.js

- [x] Add a playground example in tests/dummy/app/pods/docs/components/amount-input/all-options/template