### PR TITLE
Drop node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '12'
+  NODE_VERSION: '14'
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.73.0"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "14.* || >= 16.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Node 12 is no longer LTS and update will be needed for ember-cli-addon-docs update.

It should be released in major version.