### PR TITLE
Add named argument `@inputId` to allow setting the input id

### DIFF
--- a/addon/components/amount-input.hbs
+++ b/addon/components/amount-input.hbs
@@ -5,7 +5,7 @@
 
   <input
     class="amount-input__value {{@inputClass}} {{if @disabled 'disabled'}}"
-    id='amount-input'
+    id={{this.inputId}}
     type='number'
     value={{@value}}
     step={{this.step}}

--- a/addon/components/amount-input.js
+++ b/addon/components/amount-input.js
@@ -45,6 +45,15 @@ export default class AmountInput extends Component {
   */
 
   /**
+    A custom id applied on the input
+    @argument inputId
+    @type String?
+  */
+  get inputId() {
+    return this.argOrDefault('inputId', 'amount-input')
+  }
+
+  /**
     Defines the argument sent to toFixed()
     Can be n>=0
     @argument numberOfDecimal

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -20,6 +20,7 @@ module('Integration | Component | amount-input', function(hooks) {
 
     await render(hbs`
       <AmountInput
+        @inputId='abcd'
         @currency="USD"
         @numberOfDecimal={{0}}
         @placeholder="1.000.000"
@@ -30,6 +31,7 @@ module('Integration | Component | amount-input', function(hooks) {
 
     assert.dom('.amount-input__currency').hasText('USD')
     assert.dom('input').hasValue('1')
+    assert.dom('input').hasAttribute('id', 'abcd')
 
     await fillIn('input', '10.726')
     await blur('input')
@@ -46,11 +48,13 @@ module('Integration | Component | amount-input', function(hooks) {
         @numberOfDecimal={{this.isUndefined}}
         @placeholder={{this.isUndefined}}
         @step={{this.isUndefined}}
+        @inputId={{this.isUndefined}}
         @value={{this.value}}
         @update={{fn (mut this.value)}} />
     `)
     assert.dom('.amount-input__currency').hasText('')
     assert.dom('input').hasNoAttribute('placeholder')
+    assert.dom('input').hasNoAttribute('id')
 
     // test numberOfDecimal
     await fillIn('input', '10.726')
@@ -68,6 +72,7 @@ module('Integration | Component | amount-input', function(hooks) {
 
     assert.dom('.amount-input__currency').hasText('EUR')
     assert.dom('input').hasAttribute('placeholder', '0.00')
+    assert.dom('input').hasAttribute('id', 'amount-input')
 
     // test numberOfDecimal
     await fillIn('input', '10.726')


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

Currently the input id defaults to `amount-input`. If you have more than one `<AmountInput/>` in a document their ids are no longer unique, element ids should be unique. This PR keeps the default `amount-input` id but let you override it using `@inputId` argument.

#### Changes
[//]: # "Add if relevant, remove if not"
* Add named argument `@inputId` to allow setting the input id

### Checklist 

- [x] Do not forget to write inline documentation for your code in addon/components/amount-input

- [x] Add a test, probably in tests/integration/components/amount-input.js

This last checklist item doesn't appear relevant anymore
~- [ ] Add a playground example in tests/dummy/app/pods/docs/components/amount-input/all-options/template~

