### PR TITLE
Added readonly attribute

### DIFF
--- a/addon/components/amount-input.hbs
+++ b/addon/components/amount-input.hbs
@@ -11,6 +11,7 @@
     step={{this.step}}
     placeholder={{this.placeholder}}
     disabled={{@disabled}}
+    readonly={{@readonly}}
     {{on 'keydown' this.onKeyDown}}
     {{on 'input' this.onInput}}
     {{on 'focusout' this.onFocusOut}}

--- a/addon/components/amount-input.js
+++ b/addon/components/amount-input.js
@@ -39,6 +39,12 @@ export default class AmountInput extends Component {
   */
 
   /**
+    Set readonly the input
+    @argument readonly
+    @type Boolean?
+  */
+
+  /**
     A custom class applied on the input
     @argument inputClass
     @type String?

--- a/tests/dummy/app/templates/docs/components/amount-input.md
+++ b/tests/dummy/app/templates/docs/components/amount-input.md
@@ -24,6 +24,18 @@
   <demo.snippet @name="amount-input-disabled"/>
 </DocsDemo>
 
+<h2>Readonly</h2>
+
+<DocsDemo as |demo|>
+  <demo.example @name="amount-input-readonly">
+    <AmountInput
+      @value={{924.67}}
+      @readonly={{true}}
+    />
+  </demo.example>
+  <demo.snippet @name="amount-input-readonly"/>
+</DocsDemo>
+
 <h2>Advanced</h2>
 
 <DocsDemo as |demo|>

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -81,6 +81,18 @@ module('Integration | Component | amount-input', function(hooks) {
     assert.dom('input').hasValue('10.73')
   })
 
+  test('Should not type in when readonly attribute is true', async function(assert) {
+    await render(hbs`
+      <AmountInput
+        @value={{this.value}}
+        @update={{fn (mut this.value)}} 
+        @readonly={{true}} />
+    `)
+
+    // test type in
+    assert.rejects(fillIn('input', '10.726'))
+  })
+
   test('e, . and , key should be masked when numberOfDecimal={{0}}', async function(assert) {
     this.set('value', 1)
 


### PR DESCRIPTION
#### Description
[//]: # Added readonly attribute (resolve #307)

#### Changes
[//]: # "Add if relevant, remove if not"
* Added readonly attribute to the component
* Added test ad updated docs


### Checklist 
- [X] Obvisously, add your option

- [X] Do not forget to write inline documentation for your code in addon/components/amount-input

- [X] Add a test, probably in tests/integration/components/amount-input.js

- [ ] Add a playground example in tests/dummy/app/pods/docs/components/amount-input/all-options/template