### PR TITLE
use already parsed e.target.valueAsNumber value instead of e.target.value

### DIFF
--- a/addon/components/amount-input.js
+++ b/addon/components/amount-input.js
@@ -122,11 +122,10 @@ export default class AmountInput extends Component {
 
   @action
   onFocusOut(e) {
-    var { value } = e.target
-    if (value) {
+    var { valueAsNumber } = e.target
+    if (valueAsNumber) {
       // add decimals
-      var floatValue = parseFloat(value)
-      this.args.update?.(floatValue.toFixed(this.numberOfDecimal))
+      this.args.update?.(valueAsNumber.toFixed(this.numberOfDecimal))
     }
   }
 }


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

This MR makes use of the [valueAsNumber](https://www.w3.org/TR/2011/WD-html5-20110405/common-input-element-attributes.html#dom-input-valueasnumber) property of input, instead of parsing manually the value as a float.

[caniuse table](https://caniuse.com/mdn-api_htmlinputelement_valueasnumber)

#### Changes
[//]: # "Add if relevant, remove if not"
* use `e.currentTarget.valueAsNumber` instead of `e.currentTarget.value` in the onFocusOut handler
* Remove the parseFloat call as this already returns a float.