### PR TITLE
fix issue where 0 would not trigger an update call on blur

### DIFF
--- a/addon/components/amount-input.js
+++ b/addon/components/amount-input.js
@@ -128,8 +128,8 @@ export default class AmountInput extends Component {
 
   @action
   onFocusOut(e) {
-    var { valueAsNumber } = e.target
-    if (valueAsNumber) {
+    var { valueAsNumber, value } = e.target
+    if (value) {
       // add decimals
       this.args.update?.(valueAsNumber.toFixed(this.numberOfDecimal))
     }

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -93,6 +93,19 @@ module('Integration | Component | amount-input', function(hooks) {
     assert.rejects(fillIn('input', '10.726'))
   })
 
+  test('should call update with the formatted value on blur if the value is 0', async function(assert) {
+    await render(hbs`
+    <AmountInput
+    @numberOfDecimal={{1}}
+    @value={{this.value}}
+    @update={{fn (mut this.value)}} />
+    `)
+
+    await fillIn('input', '0')
+    await blur('input')
+    assert.dom('input').hasValue('0.0')
+  })
+
   test('e, . and , key should be masked when numberOfDecimal={{0}}', async function(assert) {
     this.set('value', 1)
 


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

This MR fixes an issue I introduced in https://github.com/qonto/ember-amount-input/pull/410 where falsy numbers (0; 0.00 etc) would not trigger the extra `update` call with a formatted value. 🙇🏾 

#### Changes
[//]: # "Add if relevant, remove if not"
* Add failing test `should call update with the formatted value on blur if the value is 0`
* Fix the condition used to call this.args.update in the onFocusOut handler.