### PR TITLE
Expose min and max attributes

### DIFF
--- a/addon/components/amount-input.hbs
+++ b/addon/components/amount-input.hbs
@@ -8,6 +8,8 @@
     id={{this.inputId}}
     type='number'
     value={{@value}}
+    min={{@min}}
+    max={{@max}}
     step={{this.step}}
     placeholder={{this.placeholder}}
     disabled={{@disabled}}

--- a/addon/components/amount-input.js
+++ b/addon/components/amount-input.js
@@ -80,6 +80,18 @@ export default class AmountInput extends Component {
   }
 
   /**
+    The min attribute specifies the minimum value for the amount <input> element.
+    @argument min
+    @type Number
+  */
+
+  /**
+    The max attribute specifies the maximum value for the amount <input> element.
+    @argument max
+    @type Number
+  */
+
+  /**
     The input's value.
     Should be updated using the `update()` argument
     @argument value

--- a/tests/dummy/app/templates/docs/components/amount-input.md
+++ b/tests/dummy/app/templates/docs/components/amount-input.md
@@ -36,6 +36,24 @@
   <demo.snippet @name="amount-input-readonly"/>
 </DocsDemo>
 
+<h2>Min & Max</h2>
+
+<DocsDemo as |demo|>
+  <demo.example @name="amount-input-min-max">
+    <form>
+        <AmountInput
+          @value={{this.value}}
+          @min={{1}}
+          @max={{1000}}
+          @update={{fn (mut this.value)}}
+        />
+        <button style="background:white; border:1px solid rgb(233,234,240); margin-top:10px; padding:2px">Submit
+        </button>
+    </form>
+  </demo.example>
+  <demo.snippet @name="amount-input-min-max"/>
+</DocsDemo>
+
 <h2>Advanced</h2>
 
 <DocsDemo as |demo|>

--- a/tests/integration/components/amount-input/component-test.js
+++ b/tests/integration/components/amount-input/component-test.js
@@ -26,6 +26,8 @@ module('Integration | Component | amount-input', function(hooks) {
         @placeholder="1.000.000"
         @step={{1}}
         @value={{this.value}}
+        @min={{5}}
+        @max={{10}}
         @update={{fn (mut this.value)}} />
     `)
 
@@ -39,6 +41,8 @@ module('Integration | Component | amount-input', function(hooks) {
     assert.dom('input').hasValue('11')
 
     assert.dom('input').hasAttribute('placeholder', '1.000.000')
+    assert.dom('input').hasAttribute('min', '5')
+    assert.dom('input').hasAttribute('max', '10')
   })
 
   test('defaults are not used if named property declared even if undefined', async function(assert) {


### PR DESCRIPTION
#### Description
This MR is to address the issue #151 [Expose min and max attributes on the input element](https://github.com/qonto/ember-amount-input/issues/151)
#### Screenshots
No UI Changes
### Checklist
- [x] exposed the min and max attributes of the Amount component
- [x] Added inline documentation for the code in addon/components/amount-input
- [x] Updated a test in tests/integration/components/amount-input.js
- [x] Added a playground example in tests/dummy/app/pods/docs/components/amount-input/all-options/template