### PR TITLE
ci: remove double node installation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
@@ -42,13 +39,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
           no-lockfile: true
       - name: Install dependencies
         run: pnpm install --no-lockfile
@@ -79,14 +74,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: "https://registry.npmjs.org"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16
+          node-registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: pnpm install
       - name: Build addon


### PR DESCRIPTION
`NullVoxPopuli/action-setup-pnpm` already handles node setup, so we are running `actions/setup-node` twice