### PR TITLE
ci: remove double pnpm install on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          args: '--frozen-lockfile'
       - name: Lint
         run: pnpm lint
       - name: Run tests
@@ -45,8 +44,6 @@ jobs:
           pnpm-version: 8.5.1
           node-version: 16.x
           no-lockfile: true
-      - name: Install dependencies
-        run: pnpm install --no-lockfile
       - name: Run tests
         run: pnpm test:ember
         working-directory: test-app
@@ -79,8 +76,7 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          args: '--frozen-lockfile'
       - name: Run tests
         run: pnpm ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
         working-directory: test-app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
           pnpm-version: 8.5.1
           node-version: 16
           node-registry-url: "https://registry.npmjs.org"
-      - name: Install dependencies
-        run: pnpm install
       - name: Build addon
         run: pnpm build
       - name: auto-dist-tag


### PR DESCRIPTION
This MR removes the double `pnpm install`: `NullVoxPopuli/action-setup-pnpm` already calls `pnpm install` and expose an `args` input