### PR TITLE
ci: use packageManager to set pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
-          pnpm-version: 8.5.1
           node-version: 16.x
           args: '--frozen-lockfile'
       - name: Lint
@@ -41,7 +40,6 @@ jobs:
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
-          pnpm-version: 8.5.1
           node-version: 16.x
           no-lockfile: true
       - name: Run tests
@@ -74,7 +72,6 @@ jobs:
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
-          pnpm-version: 8.5.1
           node-version: 16.x
           args: '--frozen-lockfile'
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
-          pnpm-version: 8.5.1
           node-version: 16
           node-registry-url: "https://registry.npmjs.org"
       - name: Build addon

--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   },
   "volta": {
     "node": "18.15.0"
-  }
+  },
+  "packageManager": "pnpm@8.6.5"
 }


### PR DESCRIPTION
This MR use the packageManager as the source of truth for pnpm version in CI. 
This remove duplication (and potential errors) in the ci files.
The [setup-pnpm action](https://github.com/NullVoxPopuli/action-setup-pnpm#support) and [dependabot](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb) already support this.  
