### PR TITLE
Bug fix: Prevent event propagation on invalid key presses

### DIFF
--- a/ember-amount-input/src/components/amount-input.js
+++ b/ember-amount-input/src/components/amount-input.js
@@ -123,11 +123,13 @@ export default class AmountInput extends Component {
   @action
   onKeyDown(event) {
     if (event.keyCode === KEY_CODE_E) {
+      event.preventDefault();
       return false;
     } else if (
       this.numberOfDecimal === 0 &&
       [KEY_CODE_FULLSTOP, KEY_CODE_COMMA].includes(event.keyCode)
     ) {
+      event.preventDefault();
       return false;
     }
   }


### PR DESCRIPTION
Hello! I noticed a behaviour that looks a bit weird to me and led to a bug ticket in Production ([here](https://www.notion.so/qonto/Cannot-input-0-as-last-cents-digit-in-Instant-card-creation-flow-budget-for-the-card-5bedadb8c2704010957f133be29b590b) for Qonto employees).

When `@numberOfDecimal` is set to `0` (so `@value` should always be an integer), following filtering logic is used for `e`, `,`, and `.` key presses:
```javascript
// ember-amount-input/src/components/amount-input.js
  @action
  onKeyDown(event) {
    if (event.keyCode === KEY_CODE_E) {
      return false;
    } else if (
      this.numberOfDecimal === 0 &&
      [KEY_CODE_FULLSTOP, KEY_CODE_COMMA].includes(event.keyCode)
    ) {
      return false;
    }
  }
```
But, since the events are not prevented from bubbling, you can actually type those characters in the input. The value is then converted to an integer on focus out. This leads to some weird states because inputs like `10.5` are actually `NaN`, while `10,5` would be correctly rounded to `10`.

You can see here how the input behaves before and after preventing events from bubbling.
With propagation:

https://github.com/qonto/ember-amount-input/assets/73175085/d77b52df-5430-40b4-98bb-58646288963b


Without propagation:

https://github.com/qonto/ember-amount-input/assets/73175085/b5911449-23e0-4c19-be67-750c14d21ea6

I think preventing the event from propagating would make the component behave in a more rational way: if the input value is an integer, you shouldn't even be allowed to type `e` or a comma in the same way you can't type a letter or any other symbol.

Note on testing: I tried modifying the existing tests, but it seems that `typeIn` testing helper doesn't actually work like manually typing, so I don't think there's really a way to test this behaviour. The changes added in the PR don't make `e, . and , key should be masked when numberOfDecimal={{0}}` test fail.