### PR TITLE
Auto update lock file with dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/test-app"
+  directory: "/"
   schedule:
-    interval: monthly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  versioning-strategy: increase
-
-- package-ecosystem: npm
-  directory: "/ember-amount-input"
-  schedule:
-    interval: monthly
-    time: "04:00"
+    interval: weekly
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
Following https://github.com/qonto/ember-lottie/pull/156 . The dependabot config might need to be updated to properly handle pnpm workspaces. 
I also updated schedule interval to weekly for consistency.