### PR TITLE
Update action to setup pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16.x
-          no-lockfile: true
+          args: "--no-lockfile"
       - name: Run tests
         run: pnpm test:ember
         working-directory: test-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16.x
-          args: '--frozen-lockfile'
+          args: "--frozen-lockfile"
       - name: Lint
         run: pnpm lint
       - name: Run tests
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16.x
           no-lockfile: true
@@ -70,10 +70,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16.x
-          args: '--frozen-lockfile'
+          args: "--frozen-lockfile"
       - name: Run tests
         run: pnpm ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
         working-directory: test-app


### PR DESCRIPTION
We want to use `wyvox/action-setup-pnpm@v3` (instead of `NullVoxPopuli/action-setup-pnpm@v2`) in our CI script.

Indeed, `NullVoxPopuli/action-setup-pnpm` has been [archived](https://github.com/NullVoxPopuli/action-setup-pnpm) and moved to [another repository](https://github.com/wyvox/action-setup-pnpm).

We also stop using the `no-lockfile` boolean option, as it has been dropped in the [last release](https://github.com/wyvox/action-setup-pnpm/releases/tag/v3.0.0), and it's now recommended to pass the pnpm option `--no-lockfile` directly via the args.