### PR TITLE
Update action to setup pnpm in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           node-version: 16
           node-registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
This PR is a follow-up of [this one](https://github.com/qonto/ember-amount-input/pull/546), where we migrated from `NullVoxPopuli/action-setup-pnpm@v2` to `wyvox/action-setup-pnpm@v3` in the CI jobs script. Here we take care of the release script.