### PR TITLE
chore: update dependabot config interval from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
After this first [PR](https://github.com/qonto/ember-amount-input/pull/550), we update the interval of the dependabot.yml config back to a weekly interval.