### PR TITLE
chore(deps): bump embroider versions in ember-try config

### DIFF
--- a/ember-amount-input/package.json
+++ b/ember-amount-input/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-proposal-decorators": "^7.23.0",
     "@babel/plugin-syntax-decorators": "^7.22.10",
     "@babel/preset-typescript": "^7.23.0",
-    "@embroider/addon-dev": "^3.0.0",
+    "@embroider/addon-dev": "^4.1.0",
     "@glimmer/component": "^1.1.2",
     "@glint/core": "^1.1.0",
     "@glint/environment-ember-loose": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^7.23.0
         version: 7.23.0(@babel/core@7.23.0)
       '@embroider/addon-dev':
-        specifier: ^3.0.0
-        version: 3.0.0(rollup@3.29.3)
+        specifier: ^4.1.0
+        version: 4.1.0(@glint/template@1.1.0)(rollup@3.29.3)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.23.0)
@@ -1965,14 +1965,14 @@ packages:
       - supports-color
     dev: true
 
-  /@embroider/addon-dev@3.0.0(rollup@3.29.3):
-    resolution: {integrity: sha512-h3ISDdp8LASA6583WC3IU3ECZ5fHlW3V3EkgpEeeH7KhxTerHjDjNf+S6+ZvPH+ZHi3WOCYPvUA5OfNICyMbtA==}
+  /@embroider/addon-dev@4.1.0(@glint/template@1.1.0)(rollup@3.29.3):
+    resolution: {integrity: sha512-DR9mGlFxcXFIP9jmVbYhy0CwxIzVqMppiIg8at9C+qayr3Wj3SdS7jM95p0kxv3mMgOYs+Z6FsAaj2em6aRs4w==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     dependencies:
-      '@embroider/core': 2.1.1
+      '@embroider/core': 3.2.1(@glint/template@1.1.0)
       '@rollup/pluginutils': 4.2.1
-      assert-never: 1.2.1
+      content-tag: 1.1.0
       fs-extra: 10.1.0
       minimatch: 3.1.2
       rollup-plugin-copy-assets: 2.0.3(rollup@3.29.3)
@@ -1980,6 +1980,7 @@ packages:
       walk-sync: 3.0.0
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@glint/template'
       - bufferutil
       - canvas
       - rollup
@@ -1997,29 +1998,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/core@2.1.1:
-    resolution: {integrity: sha512-N4rz+r8WjHYmwprvBYC0iUT4EWNpdDjF7JLl8PEYlWbhXDEJL+Ma/aP78S7spMhIpJX9SHK7nbgNxmZAqAe34A==}
+  /@embroider/core@3.2.1(@glint/template@1.1.0):
+    resolution: {integrity: sha512-GhKc9pqPcbKpvUkhTnRqJhr3Pc4xslnzhrGQqBDBNwOZ0/zUU02wpiB+PmiA3+mZFTZNQoUCq4A7vm5dXraQug==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       '@babel/core': 7.23.0
       '@babel/parser': 7.23.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.0)
-      '@babel/runtime': 7.23.1
       '@babel/traverse': 7.23.0
-      '@embroider/macros': 1.10.0
-      '@embroider/shared-internals': 2.0.0
+      '@embroider/macros': 1.13.1(@glint/template@1.1.0)
+      '@embroider/shared-internals': 2.4.0
       assert-never: 1.2.1
-      babel-import-util: 1.4.1
-      babel-plugin-ember-template-compilation: 2.0.3
+      babel-plugin-ember-template-compilation: 2.2.0
       broccoli-node-api: 1.7.0
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       debug: 4.3.4
-      escape-string-regexp: 4.0.0
       fast-sourcemap-concat: 1.4.0
-      filesize: 5.0.3
+      filesize: 10.0.7
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.7
@@ -2031,26 +2027,11 @@ packages:
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
+      - '@glint/template'
       - bufferutil
       - canvas
       - supports-color
       - utf-8-validate
-    dev: true
-
-  /@embroider/macros@1.10.0:
-    resolution: {integrity: sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@embroider/shared-internals': 2.0.0
-      assert-never: 1.2.1
-      babel-import-util: 1.4.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.3
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@embroider/macros@1.13.0(@glint/template@1.1.0):
@@ -2094,20 +2075,6 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@embroider/shared-internals@2.0.0:
-    resolution: {integrity: sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      babel-import-util: 1.4.1
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      resolve-package-path: 4.0.3
-      semver: 7.5.4
-      typescript-memoize: 1.1.1
     dev: true
 
   /@embroider/shared-internals@2.3.0:
@@ -4288,6 +4255,14 @@ packages:
     engines: {node: '>= 12.*'}
     dependencies:
       babel-import-util: 1.4.1
+
+  /babel-plugin-ember-template-compilation@2.2.0:
+    resolution: {integrity: sha512-1I7f5gf06h5wKdKUvaYEIaoSFur5RLUvTMQG4ak0c5Y11DWUxcoX9hrun1xe9fqfY2dtGFK+ZUM6sn6z8sqK/w==}
+    engines: {node: '>= 12.*'}
+    dependencies:
+      '@glimmer/syntax': 0.84.3
+      babel-import-util: 2.0.0
+    dev: true
 
   /babel-plugin-filter-imports@4.0.0:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
@@ -6498,6 +6473,10 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
+
+  /content-tag@1.1.0:
+    resolution: {integrity: sha512-bktivDORs9M890KwVKrIONYvHhwshfgF4b1G/TFPrjH12Ag2GDiSdxVHqIzMxWZ297VgIRPSImURlpcOzJP/LQ==}
     dev: true
 
   /content-type@1.0.5:
@@ -9515,11 +9494,6 @@ packages:
   /filesize@10.0.7:
     resolution: {integrity: sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==}
     engines: {node: '>= 10.4.0'}
-    dev: true
-
-  /filesize@5.0.3:
-    resolution: {integrity: sha512-RM123v6KPqgZJmVCh4rLvCo8tLKr4sgD92DeZ+AuoUE8teGZJHKs1cTORwETcpIJSlGsz2WYdwKDQUXby5hNqQ==}
-    engines: {node: '>= 0.4.0'}
     dev: true
 
   /fill-range@4.0.0:

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -65,8 +65,24 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      embroiderSafe({
+        npm: {
+          devDependencies: {
+            '@embroider/compat': '^3.2.1',
+            '@embroider/core': '^3.2.1',
+            '@embroider/webpack': '^3.1.5',
+          },
+        },
+      }),
+      embroiderOptimized({
+        npm: {
+          devDependencies: {
+            '@embroider/compat': '^3.2.1',
+            '@embroider/core': '^3.2.1',
+            '@embroider/webpack': '^3.1.5',
+          },
+        },
+      }),
     ],
   };
 };


### PR DESCRIPTION
We want to bump `@embroider/addon-dev` from 3.0.0 to 4.1.0.

However, Ember-try's default configuration with pnpm installs lower versions of embroider devDependencies when running ember-try scenarios. So we need to bump embroider dependencies in ember-try config to make sure newer versions are installed in order to fix embroider ember-try CI jobs failing.

It should resolve https://github.com/qonto/ember-amount-input/pull/568.

See https://github.com/qonto/ember-phone-input/pull/732 and https://github.com/qonto/ember-autofocus-modifier/pull/409 for references.