### PR TITLE
chore: replace Travis-CI build status badge with GitHub CI workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,31 @@
 ![ember-amount-input-illustration](https://user-images.githubusercontent.com/15218861/189690446-b3f1189f-94b0-464a-8875-2b065160ba14.svg)
 
-ember-amount-input
-==============================================================================
+# ember-amount-input
 
 [![Build Status](https://img.shields.io/travis/qonto/ember-phone-input.svg?style=flat-square)](https://travis-ci.com/qonto/ember-amount-input)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-amount-input.svg)](https://emberobserver.com/addons/ember-amount-input)
 
 Easily create a money input with the currency of your liking.
 
+## Compatibility
 
-Compatibility
-------------------------------------------------------------------------------
+- Ember.js v3.28 or above
+- Embroider or ember-auto-import v2
 
-* Ember.js v3.28 or above
-* Embroider or ember-auto-import v2
-
-
-Installation
-------------------------------------------------------------------------------
+## Installation
 
 ```
 ember install ember-amount-input
 ```
 
-
-Usage
-------------------------------------------------------------------------------
+## Usage
 
 [View the docs here](https://qonto.github.io/ember-amount-input/)
 
-
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ember-amount-input
 
-[![Build Status](https://img.shields.io/travis/qonto/ember-phone-input.svg?style=flat-square)](https://travis-ci.com/qonto/ember-amount-input)
+![CI](https://github.com/qonto/ember-amount-input/workflows/CI/badge.svg)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-amount-input.svg)](https://emberobserver.com/addons/ember-amount-input)
 
 Easily create a money input with the currency of your liking.


### PR DESCRIPTION
We are not using Travis-CI anymore for this project. We can’t use the build status badge on the README anymore. So we propose to replace it with a badge displaying the status of the GitHub CI workflow (master branch). You can have a preview of the updated README via this [link](https://github.com/qonto/ember-amount-input/tree/update-build-badge).