### PR TITLE
ci: add LTS ember-try scenarios for v4.8.0 and v4.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         ember-try-scenario:
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
+          - ember-lts-4.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -24,6 +24,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
In a [previous PR](https://github.com/qonto/ember-amount-input/pull/552), we bumped `ember-source` to v5 in test-app. So we want to add new test scenarios to the CI, for LTS versions (v.4.8.0 and v4.12.0).

Give a look at the [checks of this PR](https://github.com/qonto/ember-amount-input/actions/runs/6341923874) to see the new two new ones.

See [Ember LTS versions](https://emberjs.com/releases/lts/).