### PR TITLE
chore: install and use @qonto/eslint-config-typescript@1.0.0-rc.0

### DIFF
--- a/ember-amount-input/.eslintrc.cjs
+++ b/ember-amount-input/.eslintrc.cjs
@@ -45,67 +45,7 @@ module.exports = {
     // ts files
     {
       files: ['**/*.ts'],
-      extends: [
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
-      ],
-      rules: {
-        // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts
-        '@typescript-eslint/no-explicit-any': 'error',
-        '@typescript-eslint/no-non-null-assertion': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict.ts
-        '@typescript-eslint/array-type': [
-          'error',
-          {
-            default: 'array',
-            readonly: 'array',
-          },
-        ],
-        '@typescript-eslint/ban-tslint-comment': 'error',
-        '@typescript-eslint/class-literal-property-style': 'error',
-        '@typescript-eslint/consistent-generic-constructors': 'error',
-        '@typescript-eslint/consistent-indexed-object-style': 'error',
-        '@typescript-eslint/consistent-type-assertions': 'error',
-        '@typescript-eslint/consistent-type-definitions': 'error',
-        '@typescript-eslint/consistent-type-imports': 'error',
-        '@typescript-eslint/explicit-function-return-type': 'error',
-        '@typescript-eslint/explicit-member-accessibility': [
-          'error',
-          {
-            accessibility: 'no-public',
-          },
-        ],
-        '@typescript-eslint/explicit-module-boundary-types': 'error',
-        '@typescript-eslint/member-delimiter-style': 'error',
-        '@typescript-eslint/member-ordering': 'error',
-        '@typescript-eslint/method-signature-style': 'error',
-        '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-        '@typescript-eslint/no-duplicate-enum-values': 'error',
-        '@typescript-eslint/no-dynamic-delete': 'error',
-        '@typescript-eslint/no-extraneous-class': 'error',
-        '@typescript-eslint/no-import-type-side-effects': 'error',
-        '@typescript-eslint/no-invalid-void-type': 'error',
-        '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
-        '@typescript-eslint/no-require-imports': 'error',
-        '@typescript-eslint/no-type-alias': [
-          'error',
-          {
-            allowGenerics: 'always',
-          },
-        ],
-        '@typescript-eslint/no-unsafe-declaration-merging': 'error',
-        '@typescript-eslint/parameter-properties': 'error',
-        '@typescript-eslint/prefer-enum-initializers': 'error',
-        '@typescript-eslint/prefer-for-of': 'error',
-        '@typescript-eslint/prefer-function-type': 'error',
-        '@typescript-eslint/prefer-literal-enum-member': 'error',
-        '@typescript-eslint/prefer-ts-expect-error': 'error',
-        '@typescript-eslint/sort-type-constituents': 'error',
-        '@typescript-eslint/type-annotation-spacing': 'error',
-        '@typescript-eslint/typedef': 'error',
-        '@typescript-eslint/unified-signatures': 'error',
-      },
+      extends: ['@qonto/eslint-config-typescript'],
     },
   ],
 };

--- a/ember-amount-input/package.json
+++ b/ember-amount-input/package.json
@@ -49,6 +49,7 @@
     "@glint/core": "^1.2.1",
     "@glint/environment-ember-loose": "^1.2.1",
     "@glint/template": "^1.2.1",
+    "@qonto/eslint-config-typescript": "1.0.0-rc.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@glint/template':
         specifier: ^1.2.1
         version: 1.2.1
+      '@qonto/eslint-config-typescript':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(eslint@8.52.0)(typescript@5.2.2)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.23.2)(rollup@3.29.4)
@@ -139,6 +142,9 @@ importers:
       '@glint/template':
         specifier: 1.2.1
         version: 1.2.1
+      '@qonto/eslint-config-typescript':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(eslint@8.52.0)(typescript@5.2.2)
       '@tsconfig/ember':
         specifier: ^3.0.1
         version: 3.0.1
@@ -2684,6 +2690,21 @@ packages:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+    dev: true
+
+  /@qonto/eslint-config-typescript@1.0.0-rc.0(eslint@8.52.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-laAtWhbOEaJH/Rq649bDM4gUW1OfVMNOgKe1Fg1R0/pCCmQgQ6AP0dz97Yj390HvHC4EDwiaPh8c7+agL/KY8A==}
+    engines: {node: '>= 18.*'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.52.0)(typescript@5.2.2)
+      eslint: 8.52.0
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@rollup/plugin-babel@6.0.4(@babel/core@7.23.2)(rollup@3.29.4):

--- a/test-app/.eslintrc.js
+++ b/test-app/.eslintrc.js
@@ -55,67 +55,7 @@ module.exports = {
     // ts files
     {
       files: ['**/*.ts'],
-      extends: [
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
-      ],
-      rules: {
-        // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts
-        '@typescript-eslint/no-explicit-any': 'error',
-        '@typescript-eslint/no-non-null-assertion': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
-        // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict.ts
-        '@typescript-eslint/array-type': [
-          'error',
-          {
-            default: 'array',
-            readonly: 'array',
-          },
-        ],
-        '@typescript-eslint/ban-tslint-comment': 'error',
-        '@typescript-eslint/class-literal-property-style': 'error',
-        '@typescript-eslint/consistent-generic-constructors': 'error',
-        '@typescript-eslint/consistent-indexed-object-style': 'error',
-        '@typescript-eslint/consistent-type-assertions': 'error',
-        '@typescript-eslint/consistent-type-definitions': 'error',
-        '@typescript-eslint/consistent-type-imports': 'error',
-        '@typescript-eslint/explicit-function-return-type': 'error',
-        '@typescript-eslint/explicit-member-accessibility': [
-          'error',
-          {
-            accessibility: 'no-public',
-          },
-        ],
-        '@typescript-eslint/explicit-module-boundary-types': 'error',
-        '@typescript-eslint/member-delimiter-style': 'error',
-        '@typescript-eslint/member-ordering': 'error',
-        '@typescript-eslint/method-signature-style': 'error',
-        '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-        '@typescript-eslint/no-duplicate-enum-values': 'error',
-        '@typescript-eslint/no-dynamic-delete': 'error',
-        '@typescript-eslint/no-extraneous-class': 'error',
-        '@typescript-eslint/no-import-type-side-effects': 'error',
-        '@typescript-eslint/no-invalid-void-type': 'error',
-        '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
-        '@typescript-eslint/no-require-imports': 'error',
-        '@typescript-eslint/no-type-alias': [
-          'error',
-          {
-            allowGenerics: 'always',
-          },
-        ],
-        '@typescript-eslint/no-unsafe-declaration-merging': 'error',
-        '@typescript-eslint/parameter-properties': 'error',
-        '@typescript-eslint/prefer-enum-initializers': 'error',
-        '@typescript-eslint/prefer-for-of': 'error',
-        '@typescript-eslint/prefer-function-type': 'error',
-        '@typescript-eslint/prefer-literal-enum-member': 'error',
-        '@typescript-eslint/prefer-ts-expect-error': 'error',
-        '@typescript-eslint/sort-type-constituents': 'error',
-        '@typescript-eslint/type-annotation-spacing': 'error',
-        '@typescript-eslint/typedef': 'error',
-        '@typescript-eslint/unified-signatures': 'error',
-      },
+      extends: ['@qonto/eslint-config-typescript'],
     },
   ],
 };

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -37,6 +37,7 @@
     "@glint/core": "1.2.1",
     "@glint/environment-ember-loose": "1.2.1",
     "@glint/template": "1.2.1",
+    "@qonto/eslint-config-typescript": "1.0.0-rc.0",
     "@tsconfig/ember": "^3.0.1",
     "@types/qunit": "^2.19.7",
     "@typescript-eslint/eslint-plugin": "^6.8.0",


### PR DESCRIPTION
Install and use our custom ESLint configuration found on https://github.com/qonto/eslint-config-typescript

The currently available version is a RC (Release Candidate) that we're testing on our public repos before making it stable.