### PR TITLE
docs: add TypeScript usage section

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -38,6 +38,26 @@ pnpm install -D ember-amount-input
 | update          | function | true     | A function triggered with the new value. Use it to update your value.                               |
 | value           | number   | true     | The input's value. It should be updated using the `update` argument.                                |
 
+## TypeScript usage
+
+The `AmountInput` component has proper [Glint](https://github.com/typed-ember/glint) types, which allow you to get strict type checking in your templates when using TypeScript.
+
+Unless you are using [strict mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html) templates (via [first class component templates](http://emberjs.github.io/rfcs/0779-first-class-component-templates.html)),
+you need to import the addon's Glint template registry entries as described in the [Using Addons](https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons#using-glint-enabled-addons) documentation:
+
+```ts
+// e.g. types/glint.d.ts
+import "@glint/environment-ember-loose";
+import type AmountInputRegistry from "ember-amount-input/template-registry";
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry
+    extends AmountInputRegistry /* other addon registries */ {
+    // local entries
+  }
+}
+```
+
 ## Examples
 
 ### Basic


### PR DESCRIPTION
In this PR, we add a section dedicated to TypeScript in DOCS.md. See [ember-lottie](https://github.com/qonto/ember-lottie#typescript-usage) for reference.