### PR TITLE
chore(commitlint): set body-max-line-length to Infinity

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,7 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "body-leading-blank": [2, "always"],
+    "body-max-line-length": [2, "always", Infinity],
     "footer-leading-blank": [2, "always"],
   },
 };


### PR DESCRIPTION
Since Dependabot commit messages body line lengths do not conform with commitlint’s current limit of 100 character, we are modifying the rule to accept an infinite number of chars.

The reasons behind this:

relying on the commit body from a third party is fragile; if dependabot updates its wording, we have to update the override
bumping to a fixed char limit is also not the best, could fail sometimes, we would be stuck (re-)bumping the limit everytime
commit body is actually not used in the changelog generation, so it won’t change much in the end