### PR TITLE
chore(ci): use master branch instead of main in CI scripts

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,7 @@ name: commitlint
 on:
   push:
     branches:
-      - main
+      - master
   pull_request: {}
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
           fetch-depth: 0
 
       - name: Verify branch name
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/master'
         run: |
-          echo "🚨 The release must start from the main branch!"
+          echo "🚨 The release must start from the master branch!"
           exit 1
 
       - name: Configure releaser details


### PR DESCRIPTION
This MR fixes a typo where we use main instead of master branch in CI workflows