### PR TITLE
feat: use KeyboardEvent.key instead of KeyboardEvent.keyCode

### DIFF
--- a/ember-amount-input/src/components/amount-input.ts
+++ b/ember-amount-input/src/components/amount-input.ts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import './amount-input.css';
 
-const KEY_CODE_E = 69;
-const KEY_CODE_FULLSTOP = 190;
-const KEY_CODE_COMMA = 188;
+const KEY_E = 'e';
+const KEY_FULLSTOP = '.';
+const KEY_COMMA = ',';
 
 export interface AmountInputArgs {
   /**
@@ -130,12 +130,13 @@ export default class AmountInput extends Component<AmountInputSignature> {
 
   @action
   onKeyDown(event: KeyboardEvent): boolean {
-    if (event.keyCode === KEY_CODE_E) {
+    const pressedKey = event.key.toLowerCase();
+    if (pressedKey === KEY_E) {
       event.preventDefault();
       return false;
     } else if (
       this.numberOfDecimal === 0 &&
-      [KEY_CODE_FULLSTOP, KEY_CODE_COMMA].includes(event.keyCode)
+      [KEY_FULLSTOP, KEY_COMMA].includes(pressedKey)
     ) {
       event.preventDefault();
       return false;


### PR DESCRIPTION
## Description 

This MR goal is to get rid of the usage of `KeyboardEvent.keyCode` which is a deprecated standard as you can see on [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). As of today, this is still supported by all browsers but might no be the case in the future. 

Two API have the potential to replace `keyCode` and they're `KeyboardEvent.code` and `KeyboardEvent.key`.

`KeyboardEvent.code` returns a representation of the key pressed while `KeyboardEvent.key` returns the value as it will be printed. In our case, we want to exclude specific printed values so `key` usage makes more sense.

Also, `KeyboardEvent.key` is more supported by browsers (partial support up to IE 8 for instance).

This PR closes #612 issue. 

## Reproduction instructions

Tests should pass. 

