### PR TITLE
Fix: prevent default behavior for the paste event

### DIFF
--- a/ember-amount-input/src/components/amount-input.ts
+++ b/ember-amount-input/src/components/amount-input.ts
@@ -157,14 +157,17 @@ export default class AmountInput extends Component<AmountInputSignature> {
 
   @action
   onPaste(event: ClipboardEvent): boolean {
+    event.preventDefault();
+
     const pastedValue = event.clipboardData?.getData('text');
     const parsedValue = parseFloat(pastedValue?.replace(/\s/g, '') ?? '');
 
     if (!isNaN(parsedValue)) {
       this.args.update(parsedValue.toFixed(this.numberOfDecimal));
+      return true;
     }
 
-    return true;
+    return false;
   }
 
   @action

--- a/test-app/tests/integration/components/amount-input/component-test.ts
+++ b/test-app/tests/integration/components/amount-input/component-test.ts
@@ -210,11 +210,11 @@ module('Integration | Component | amount-input', function (hooks) {
     module('and the value is not a valid amount', function () {
       test('calls update with an empty string value', async function (assert) {
         await render<TestContext>(hbs`
-        <AmountInput
-          @value={{this.value}}
-          @update={{fn (mut this.value)}}
-        />
-      `);
+          <AmountInput
+            @value={{this.value}}
+            @update={{fn (mut this.value)}}
+          />
+        `);
 
         await simulateUserPasteValue('input', 'foo');
 


### PR DESCRIPTION
In this MR, we want to prevent the default behavior of the paste event.

Indeed, the default behavior of the paste event includes triggering the input event right after. However, the component calls the `update` function for both events, which can lead to unexpected results.

By preventing the default behavior of the paste event, we make sure the `update` function is only called once.